### PR TITLE
[Fix] client 라우팅 구조 수정 사항 업데이트

### DIFF
--- a/client/src/pages/QuestionnairePage.tsx
+++ b/client/src/pages/QuestionnairePage.tsx
@@ -97,7 +97,7 @@ export default function QuestionnairePage() {
       STORAGE_KEYS.USER_PROFILE,
       JSON.stringify(tempProfile)
     );
-    setLoc("/style-definition/results"); // Results page path may be changed to enterprise version later
+    setLoc("/results"); // Results page path may be changed to enterprise version later
   };
 
   const next = () =>
@@ -109,7 +109,7 @@ export default function QuestionnairePage() {
   }, [idx]);
 
   return (
-    <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <main className="max-w-6xl px-4 py-8 mx-auto sm:px-6 lg:px-8">
       <ProgressBar
         currentQuestion={idx + 1}
         totalQuestions={questions.length}

--- a/client/src/pages/ResultsPage.tsx
+++ b/client/src/pages/ResultsPage.tsx
@@ -15,11 +15,11 @@ export default function ResultsPage() {
   if (!profile) return null;
 
   return (
-    <main className="max-w-6xl mx-auto p-8">
+    <main className="max-w-6xl p-8 mx-auto">
       <ResultsSummary
         userProfile={profile}
         completionRate={100}
-        onStartConversion={() => setLoc("/quality-analysis")}
+        onStartConversion={() => setLoc("/validate")}
         onExportData={() => {
           const dataStr = JSON.stringify(profile, null, 2);
           const url = URL.createObjectURL(

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -34,12 +34,12 @@ export default function HomePage() {
 
   const handleStartQuestionnaire = () => {
     setShowModal(false);
-    setLocation("/style-definition");
+    setLocation("/questionnaire");
   };
 
   const handleStartUpload = () => {
     setShowModal(false);
-    setLocation("/upload-documents");
+    setLocation("/upload");
   };
 
   const handleCloseModal = () => {
@@ -50,12 +50,12 @@ export default function HomePage() {
     try {
       const profile = localStorage.getItem("chatToner_profile");
       // If profile exists, go to converter. Otherwise, go to questionnaire.
-      const targetUrl = profile ? "/style-conversion" : "/style-definition";
+      const targetUrl = profile ? "/converter" : "/questionnaire";
       setLocation(targetUrl);
     } catch (error) {
       console.error("Error reading localStorage:", error);
       // Fallback to questionnaire if localStorage fails
-      setLocation("/style-definition");
+      setLocation("/questionnaire");
     }
   };
 
@@ -133,7 +133,7 @@ export default function HomePage() {
                 프로필에 따라 톤을 조정합니다.
               </p>
               <Button
-                onClick={() => setLocation("/quality-analysis")}
+                onClick={() => setLocation("/validate")}
                 className="w-full py-3 text-lg"
               >
                 분석기로 이동


### PR DESCRIPTION
이 풀 리퀘스트는 애플리케이션 전체의 라우팅과 네비게이션 경로를 더 간결하고 일관된 URL로 업데이트합니다. 또한 일관성을 위해 레이아웃 클래스 순서를 약간 조정합니다. 변경 사항은 사용자 네비게이션 개선과 코드 유지보수성 향상에 중점을 두고 있습니다.

**라우팅 및 네비게이션 업데이트:**
* `home.tsx`에서 설문지 시작 경로를 `/style-definition`에서 `/questionnaire`로, 문서 업로드 경로를 `/upload-documents`에서 `/upload`로 변경했습니다. 또한 `/style-conversion` 대신 `/converter`를 사용하도록 로직을 업데이트하고, 프로필이 없는 경우 `/questionnaire`로 폴백하도록 했습니다.
* 결과 페이지 네비게이션 업데이트: `QuestionnairePage.tsx`에서 설문지 제출 후 사용자가 `/style-definition/results` 대신 `/results`로 리다이렉트됩니다.
* `ResultsPage.tsx`에서 결과 페이지의 다음 단계를 `/quality-analysis` 대신 `/validate`로 변경하고, `home.tsx`의 해당 버튼도 업데이트했습니다.

**레이아웃 및 스타일 일관성:**
* 일관성을 위해 `QuestionnairePage.tsx`와 `ResultsPage.tsx`의 `main` 요소에서 CSS 유틸리티 클래스 순서를 조정했습니다 (`mx-auto` 위치 변경).