### PR TITLE
[Feat] Quality Analysis Agent Refactoring - Service Fallback & Utility Separation

### DIFF
--- a/python_backend/agents/quality_analysis_agent.py
+++ b/python_backend/agents/quality_analysis_agent.py
@@ -1,19 +1,21 @@
 """
 최적화된 기업용 Quality Analysis Agent
-단일 API 호출로 문법 + 프로토콜 통합 분석
-Agent 내부 fallback: 규칙 기반 분석 + 경량 LLM 제안
+RAG 통합 분석 → 실패 시 Agent 내부 Fallback (utils/llm 활용)
 """
 
 from typing import TypedDict, Dict, Any, List, Optional
 from langgraph.graph import StateGraph, END
 from dataclasses import dataclass
+import logging
 import json
-import asyncio
 
 from .base_agent import (
     BaseAgent, BaseAgentState, BaseAgentConfig, BaseAgentResult,
     CommonAgentNodes, AgentFactory, agent_monitor
 )
+
+logger = logging.getLogger('chattoner.quality_analysis_agent')
+
 
 class OptimizedEnterpriseQualityState(BaseAgentState):
     """기업용 Quality Analysis Agent 전용 상태"""
@@ -45,25 +47,26 @@ class OptimizedEnterpriseQualityState(BaseAgentState):
     suggestions: List[Dict[str, str]]
     protocol_suggestions: List[Dict[str, str]]
 
+
 @dataclass
 class OptimizedEnterpriseQualityConfig(BaseAgentConfig):
     """기업용 Quality Agent 설정"""
     name: str = "optimized_enterprise_quality"
-    version: str = "1.2.0"
+    version: str = "1.4.0"
     timeout: float = 35.0
     max_suggestions: int = 4
     max_protocol_suggestions: int = 4
     confidence_threshold: float = 0.6
-    enable_comprehensive_analysis: bool = True
-    enable_llm_fallback: bool = True  # LLM fallback 사용 여부
+    enable_llm_fallback: bool = True
+
 
 class OptimizedEnterpriseQualityAgent(BaseAgent):
-    """기업용 품질분석 Agent"""
+    """기업용 품질분석 Agent (RAG + 내부 Fallback)"""
     
     def __init__(self, rag_service, db_service, config: Optional[OptimizedEnterpriseQualityConfig] = None):
         super().__init__(rag_service, config or OptimizedEnterpriseQualityConfig())
         self.db_service = db_service
-    
+        
     def _build_graph(self) -> StateGraph:
         """워크플로우"""
         workflow = StateGraph(OptimizedEnterpriseQualityState)
@@ -86,7 +89,7 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
         return workflow.compile()
     
     def _create_initial_state(self, **kwargs) -> OptimizedEnterpriseQualityState:
-        """최적화된 초기 상태 생성"""
+        """초기 상태 생성"""
         return OptimizedEnterpriseQualityState(
             # 기본 입력
             text=kwargs.get('text', ''),
@@ -155,7 +158,7 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
         return state
     
     async def _comprehensive_analysis(self, state: OptimizedEnterpriseQualityState) -> OptimizedEnterpriseQualityState:
-        """통합 분석 with 내부 fallback"""
+        """RAG 기반 통합 분석 → 실패 시 Agent 내부 fallback"""
         async with self._step_context("통합 분석", state):
             # 기업 맥락 정보 구성
             company_style = state["company_profile"].get("communication_style", "formal")
@@ -193,7 +196,6 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
         "grammar_issues": [
             {{
                 "original": "문제 표현",
-                "issue": "문제점",
                 "suggestion": "개선안",
                 "reason": "개선 이유"
             }}
@@ -203,9 +205,9 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
         "protocol_score": <0-100>,
         "compliance_issues": [
             {{
-                "rule": "위반된 규칙",
-                "violation": "위반 내용",
-                "correction": "수정 방안",
+                "original": "위반 표현",
+                "suggestion": "수정 방안",
+                "reason": "위반 이유",
                 "severity": "high|medium|low"
             }}
         ],
@@ -226,7 +228,7 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
     }}
 }}"""
             
-            # 단일 RAG 호출
+            # RAG 호출
             result = await self._call_rag_with_retry(
                 prompt=comprehensive_prompt,
                 context="기업 커뮤니케이션 종합 분석"
@@ -234,7 +236,7 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
             
             if result:
                 try:
-                    # JSON 파싱
+
                     analysis_data = self._extract_json_from_text(result["answer"])
                     state["comprehensive_analysis"] = analysis_data
                     state["rag_sources"].extend(result.get("sources", []))
@@ -245,360 +247,105 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
                     
                 except (ValueError, json.JSONDecodeError) as e:
                     # JSON 파싱 실패 → Agent 내부 fallback
-                    self.logger.warning(f"JSON 파싱 실패: {e}")
-                    return await self._agent_fallback_to_rule_based(state, f"JSON 파싱 실패: {e}")
+                    self.logger.warning(f"JSON 파싱 실패: {e}, Agent 내부 fallback 시작")
+            else:
+                # RAG 호출 실패 → Agent 내부 fallback
+                self.logger.warning("RAG 호출 실패, Agent 내부 fallback 시작")
             
-            # RAG 호출 실패 → Agent 내부 fallback
-            self.logger.warning("RAG 호출 실패")
-            return await self._agent_fallback_to_rule_based(state, "RAG 호출 실패")
+            # Agent 내부 fallback 실행
+            return await self._agent_internal_fallback(state)
         
         return state
     
-    async def _agent_fallback_to_rule_based(
-        self, 
-        state: OptimizedEnterpriseQualityState,
-        reason: str
-    ) -> OptimizedEnterpriseQualityState:
-        """Agent 내부 규칙 기반 fallback: 분석 + 경량 LLM 제안"""
+    async def _agent_internal_fallback(self, state: OptimizedEnterpriseQualityState) -> OptimizedEnterpriseQualityState:
+        """
+        Agent 내부 fallback: 규칙 기반 분석 + LLM 제안
+        이미 로드된 company_profile 재사용
+        """
         from services.rewrite_service import rewrite_text
+        from utils.quality_analysis_utils import (
+            extract_base_scores, apply_expectation_gap, 
+            map_audience, map_channel, identify_concerns, create_basic_suggestions
+        )
+        from utils.quality_analysis_llm import generate_suggestions_with_llm
         
-        self.logger.info(f"규칙 기반 분석 + LLM 제안 시작 (이유: {reason})")
+        self.logger.info("Agent 내부 fallback 실행 (이미 로드된 기업 데이터 활용)")
         
-        # 1단계: rewrite_text로 분석만 수행
+        # 1) rewrite_text로 분석
         rewrite_result = rewrite_text(
             text=state["text"],
             traits={},
             context={
-                "audience": self._map_audience(state["target_audience"]),
-                "channel": self._map_channel(state["context"])
+                "audience": map_audience(state["target_audience"]),
+                "channel": map_channel(state["context"])
             },
-            options={"analysis_only": True}  # 재작성 없이 분석만
+            options={"analysis_only": True}
         )
         
-        # 2단계: 점수 계산 (기업 맥락 반영)
-        scores = self._calculate_scores_from_analysis(rewrite_result, state["company_profile"])
+        # 2) 점수 계산 (이미 로드된 company_profile 활용!)
+        base_scores = extract_base_scores(rewrite_result)
+        adjusted_scores, adjustment_info = apply_expectation_gap(
+            base_scores, 
+            state["company_profile"] if state["company_profile"] else None
+        )
         
-        # 3단계: LLM으로 구체적 제안 생성
+        # 3) LLM 제안 생성
         if self.config.enable_llm_fallback:
-            suggestions = await self._generate_suggestions_with_llm(
-                text=state["text"],
-                analysis_result=rewrite_result,
-                target_audience=state["target_audience"],
-                context=state["context"],
-                company_profile=state["company_profile"]
-            )
+            try:
+                suggestions = await generate_suggestions_with_llm(
+                    rag_service=self.rag_service,
+                    text=state["text"],
+                    rewrite_result=rewrite_result,
+                    target_audience=state["target_audience"],
+                    context=state["context"],
+                    company_profile=state["company_profile"] if state["company_profile"] else None,
+                    max_grammar=self.config.max_suggestions,
+                    max_protocol=self.config.max_protocol_suggestions
+                )
+            except Exception as e:
+                self.logger.error(f"LLM 제안 실패: {e}, 기본 제안 사용")
+
+                suggestions = create_basic_suggestions(rewrite_result)
         else:
-            # LLM 비활성화 시 기본 제안
-            suggestions = self._create_basic_suggestions(rewrite_result)
+
+            suggestions = create_basic_suggestions(rewrite_result)
         
-        # 4단계: comprehensive_analysis 구성
+        # 4) comprehensive_analysis 구성
+        grammar = rewrite_result.get("grammar", {})
+        protocol = rewrite_result.get("protocol", {})
+        
         state["comprehensive_analysis"] = {
             "grammar_analysis": {
-                "grammar_score": scores["grammar_score"],
-                "formality_score": scores["formality_score"],
-                "readability_score": scores["readability_score"],
+                "grammar_score": adjusted_scores["grammar_score"],
+                "formality_score": adjusted_scores["formality_score"],
+                "readability_score": adjusted_scores["readability_score"],
                 "grammar_issues": suggestions["grammar"]
             },
             "protocol_analysis": {
-                "protocol_score": scores["protocol_score"],
+                "protocol_score": adjusted_scores["protocol_score"],
                 "compliance_issues": suggestions["protocol"],
                 "tone_assessment": {
-                    "matches_company_tone": rewrite_result.get("protocol", {}).get("flags", {}).get("tone_consistent", True),
+                    "matches_company_tone": protocol.get("flags", {}).get("tone_consistent", True),
                     "appropriateness": "appropriate",
                     "suggestions": []
                 },
                 "format_compliance": {
-                    "meets_format": rewrite_result.get("protocol", {}).get("flags", {}).get("format_ok", True),
-                    "required_elements": rewrite_result.get("protocol", {}).get("details", {}).get("missing_sections", [])
+                    "meets_format": protocol.get("flags", {}).get("format_ok", True),
+                    "required_elements": protocol.get("details", {}).get("missing_sections", [])
                 }
             },
             "overall_assessment": {
-                "enterprise_readiness": (scores["grammar_score"] + scores["protocol_score"]) / 2,
-                "primary_concerns": self._identify_concerns(scores),
+                "enterprise_readiness": (adjusted_scores["grammar_score"] + adjusted_scores["protocol_score"]) / 2,
+                "primary_concerns": identify_concerns(adjusted_scores),
                 "strengths": []
             }
         }
         
-        state["processing_metadata"]["analysis_method"] = "rule_based_with_llm_suggestions"
-        state["processing_metadata"]["fallback_reason"] = reason
+        state["processing_metadata"]["analysis_method"] = "agent_fallback"
+        state["processing_metadata"]["adjustment_info"] = adjustment_info
         
-        self.logger.info("규칙 기반 분석 완료")
+        self.logger.info("Agent 내부 fallback 완료")
         return state
-    
-    def _calculate_scores_from_analysis(
-        self,
-        rewrite_result: dict,
-        company_profile: dict
-    ) -> dict:
-        """rewrite 분석 결과 → 점수 계산 (기업 맥락 반영, Expectation-Gap 모델)"""
-        
-        grammar = rewrite_result.get("grammar", {})
-        protocol = rewrite_result.get("protocol", {})
-        
-        # 1) 기본 점수 추출 (텍스트 절대 평가)
-        base_grammar = grammar.get("metrics", {}).get("grammar_score", 70.0)
-        base_formality = self._extract_formality_score(grammar)
-        base_readability = self._extract_readability_score(grammar)
-        base_protocol = protocol.get("metrics", {}).get("policy_score", 0.7) * 100
-        
-        # 2) 기업 기대치 정의
-        company_style = company_profile.get("communication_style", "formal")
-        expectations = {
-            "strict": {"formality": 90, "protocol": 85},
-            "formal": {"formality": 80, "protocol": 75},
-            "friendly": {"formality": 70, "protocol": 65}
-        }
-        expected = expectations.get(company_style, expectations["formal"])
-        
-        # 3) Expectation-Gap 기반 조정
-        # Gap이 클수록 페널티 증가 (낮은 점수일수록 더 큰 페널티)
-        formality_gap = max(0, expected["formality"] - base_formality)
-        protocol_gap = max(0, expected["protocol"] - base_protocol)
-        
-        adjusted_formality = base_formality - (formality_gap * 0.2)  # 30% 조정
-        adjusted_protocol = base_protocol - (protocol_gap * 0.3)     
-        
-        adjusted_formality = max(0, min(100, adjusted_formality))
-        adjusted_protocol = max(0, min(100, adjusted_protocol))
-        
-        return {
-            "grammar_score": base_grammar,  # 문법은 절대 평가
-            "formality_score": adjusted_formality,
-            "readability_score": base_readability,  # 가독성도 절대 평가
-            "protocol_score": adjusted_protocol
-        }
-    
-    def _extract_formality_score(self, grammar: dict) -> float:
-        """격식도 점수 추출"""
-        korean_endings = grammar.get("korean_endings", {})
-        if korean_endings.get("ending_ok"):
-            return 85.0
-        
-        speech_level = korean_endings.get("speech_level", "기타")
-        speech_map = {
-            "합쇼체": 80.0,
-            "해요체": 75.0,
-            "의문형": 78.0,
-            "평서/반말": 60.0,
-            "기타": 65.0
-        }
-        return speech_map.get(speech_level, 65.0)
-    
-    def _extract_readability_score(self, grammar: dict) -> float:
-        """가독성 점수 추출 (평균 문장 길이 기반)"""
-        avg_len = grammar.get("metrics", {}).get("avg_sentence_len", 30)
-        if avg_len < 20: return 90.0
-        if avg_len < 30: return 85.0
-        if avg_len < 50: return 75.0
-        if avg_len < 80: return 65.0
-        return 55.0
-    
-    async def _generate_suggestions_with_llm(
-        self,
-        text: str,
-        analysis_result: dict,
-        target_audience: str,
-        context: str,
-        company_profile: dict
-    ) -> dict:
-        """경량 LLM으로 구체적 제안 생성"""
-        
-        grammar = analysis_result.get("grammar", {})
-        protocol = analysis_result.get("protocol", {})
-        
-        # 문제점 요약 (짧게)
-        issues_summary = self._summarize_issues(grammar, protocol)
-        
-        # 경량 프롬프트 (300-500 토큰)
-        prompt = f"""다음 텍스트의 문제점을 기반으로 구체적인 수정 제안을 생성해주세요.
-
-원문:
-{text}
-
-대상: {target_audience}
-상황: {context}
-기업 스타일: {company_profile.get("communication_style", "formal")}
-
-감지된 문제:
-{issues_summary}
-
-다음 JSON 형식으로만 응답:
-{{
-    "grammar_suggestions": [
-        {{
-            "original": "원문에서 문제 있는 구체적 표현",
-            "suggestion": "수정된 표현",
-            "reason": "수정 이유"
-        }}
-    ],
-    "protocol_suggestions": [
-        {{
-            "violation": "위반 내용",
-            "correction": "수정 방안",
-            "severity": "high|medium|low"
-        }}
-    ]
-}}
-
-최대 5개씩만 제안하세요."""
-        
-        # LLM 호출
-        result = await self._call_rag_with_retry(
-            prompt=prompt,
-            context="제안사항 생성",
-            max_retries=1  # fallback이니까 1회만 시도
-        )
-        
-        if result:
-            try:
-                suggestions_data = self._extract_json_from_text(result["answer"])
-                
-                return {
-                    "grammar": [
-                        {
-                            "category": "문법",
-                            "original": s.get("original", ""),
-                            "issue": "문법/명료성",
-                            "suggestion": s.get("suggestion", ""),
-                            "reason": s.get("reason", "")
-                        }
-                        for s in suggestions_data.get("grammar_suggestions", [])[:self.config.max_suggestions]
-                    ],
-                    "protocol": [
-                        {
-                            "category": "프로토콜",
-                            "rule": "프로토콜 위반",
-                            "violation": s.get("violation", ""),
-                            "correction": s.get("correction", ""),
-                            "severity": s.get("severity", "medium")
-                        }
-                        for s in suggestions_data.get("protocol_suggestions", [])[:self.config.max_protocol_suggestions]
-                    ]
-                }
-            except Exception as e:
-                self.logger.error(f"LLM 제안 파싱 실패: {e}")
-                # LLM 실패 시 기본 제안
-                return self._create_basic_suggestions(analysis_result)
-        
-        # LLM 완전 실패
-        return self._create_basic_suggestions(analysis_result)
-    
-    def _summarize_issues(self, grammar: dict, protocol: dict) -> str:
-        """분석 결과를 LLM이 이해할 수 있게 요약"""
-        issues = []
-        
-        # 점수 기반 체크 추가
-        grammar_score = grammar.get("metrics", {}).get("grammar_score", 70)
-        if grammar_score < 70:
-            issues.append(f"- 전반적 문법 점수 낮음 ({grammar_score:.0f}점)")
-
-        # 어미 문제
-        korean_endings = grammar.get("korean_endings", {})
-        if not korean_endings.get("ending_ok"):
-            issues.append(f"- 어미 격식: {korean_endings.get('speech_level', '부적절')}")
-        
-        # 금칙어
-        banned = protocol.get("flags", {}).get("banned_terms", [])
-        if banned:
-            issues.append(f"- 금칙어 사용: {', '.join(banned[:3])}")
-        
-        # 섹션 누락
-        missing = protocol.get("details", {}).get("missing_sections", [])
-        if missing:
-            issues.append(f"- 필수 섹션 누락: {', '.join(missing[:2])}")
-        
-        # 문장 길이
-        avg_len = grammar.get("metrics", {}).get("avg_sentence_len", 0)
-        if avg_len > 50:
-            issues.append(f"- 문장이 너무 김 (평균 {avg_len}자)")
-        
-        # 이모지
-        emoji_count = grammar.get("word_flags", {}).get("emoji_used", 0)
-        if emoji_count > 0:
-            issues.append(f"- 이모지 사용 ({emoji_count}개)")
-        
-        return "\n".join(issues) if issues else "주요 문제점 없음"
-    
-    def _create_basic_suggestions(self, analysis_result: dict) -> dict:
-        """LLM 실패 시 기본 제안 (금칙어와 섹션만)"""
-        protocol = analysis_result.get("protocol", {})
-        
-        suggestions = {
-            "grammar": [],
-            "protocol": []
-        }
-        
-        # 금칙어 (구체적)
-        banned = protocol.get("flags", {}).get("banned_terms", [])
-        for i, term in enumerate(banned[:3]):
-            suggestions["protocol"].append({
-                "category": "프로토콜",
-                "rule": "금칙어",
-                "violation": term,
-                "correction": "대체 표현 사용 필요",
-                "severity": "high"
-            })
-        
-        # 섹션 누락
-        missing = protocol.get("details", {}).get("missing_sections", [])
-        for i, section in enumerate(missing[:2]):
-            suggestions["protocol"].append({
-                "category": "프로토콜",
-                "rule": "필수 섹션",
-                "violation": f"{section} 누락",
-                "correction": f"{section} 섹션 추가 권장",
-                "severity": "medium"
-            })
-        
-        # 문법 제안은 일반적으로만
-        if not protocol.get("flags", {}).get("tone_consistent", True):
-            suggestions["grammar"].append({
-                "category": "톤",
-                "original": "[전체 텍스트]",
-                "issue": "톤 일관성",
-                "suggestion": "격식 있는 표현으로 통일",
-                "reason": "비즈니스 커뮤니케이션 톤 유지"
-            })
-        
-        return suggestions
-    
-    def _identify_concerns(self, scores: dict) -> list:
-        """주요 개선점 식별"""
-        concerns = []
-        
-        if scores["protocol_score"] < 70:
-            concerns.append("프로토콜 준수")
-        if scores["formality_score"] < 70:
-            concerns.append("격식도 조정")
-        if scores["grammar_score"] < 70:
-            concerns.append("문법 개선")
-        if scores["readability_score"] < 70:
-            concerns.append("가독성 향상")
-        
-        return concerns or ["전반적 품질 향상"]
-    
-    def _map_audience(self, target: str) -> list:
-        """대상 매핑"""
-        mapping = {
-            "직속상사": ["executives"],
-            "팀동료": ["team"],
-            "타부서담당자": ["team"],
-            "클라이언트": ["clients_vendors"],
-            "외부협력업체": ["clients_vendors"],
-            "후배신입": ["team"]
-        }
-        return mapping.get(target, ["team"])
-    
-    def _map_channel(self, context: str) -> str:
-        """채널 매핑"""
-        mapping = {
-            "보고서": "report",
-            "회의록": "meeting_minutes",
-            "이메일": "email",
-            "공지사항": "email",
-            "메시지": "chat"
-        }
-        return mapping.get(context, "email")
     
     async def _process_analysis_results(self, state: OptimizedEnterpriseQualityState) -> OptimizedEnterpriseQualityState:
         """분석 결과 처리 및 점수 계산"""
@@ -645,14 +392,13 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
         return state
     
     def _generate_suggestions_from_analysis(self, state: OptimizedEnterpriseQualityState):
-        """분석 결과에서 제안사항 생성 (RAG 형식과 통일)"""
+        """분석 결과에서 제안사항 생성"""
         # 문법 제안
         grammar_issues = state["grammar_feedback"].get("grammar_issues", [])
         state["suggestions"] = [
             {
                 "category": issue.get("category", "문법"),
                 "original": issue.get("original", ""),
-                "issue": issue.get("issue", ""),  # RAG 형식 통일
                 "suggestion": issue.get("suggestion", ""),
                 "reason": issue.get("reason", "")
             }
@@ -664,9 +410,9 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
         state["protocol_suggestions"] = [
             {
                 "category": issue.get("category", "프로토콜"),
-                "rule": issue.get("rule", ""),
-                "violation": issue.get("violation", ""),
-                "correction": issue.get("correction", ""),
+                "original": issue.get("original", ""),           # violation → original
+                "suggestion": issue.get("suggestion", ""),       # correction → suggestion
+                "reason": issue.get("reason", ""),
                 "severity": issue.get("severity", "medium")
             }
             for issue in compliance_issues[:self.config.max_protocol_suggestions]
@@ -703,8 +449,9 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
             # 메타데이터
             "company_analysis": {
                 "company_id": final_state["company_id"],
-                "communication_style": final_state["company_profile"].get("communication_style"),
-                "compliance_level": final_state["compliance_score"]
+                "communication_style": final_state["company_profile"].get("communication_style") if final_state["company_profile"] else "unknown",
+                "compliance_level": final_state["compliance_score"],
+                "adjustment_info": final_state["processing_metadata"].get("adjustment_info", {})
             },
             
             # 최적화 정보
@@ -737,11 +484,10 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
         if analysis_method == "rag_comprehensive":
             return "높음"
         
-        # LLM 제안 있으면 보통
-        if analysis_method == "rule_based_with_llm_suggestions":
+        # Agent fallback 시 보통
+        if analysis_method == "agent_fallback":
             return "보통"
         
-        # 기본 제안만 있으면 낮음
         return "낮음"
     
     # 외부 인터페이스
@@ -779,6 +525,9 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
                 }
             }
         
-        return result.data
+        output_data = result.data
+        output_data['rag_sources_count'] = result.rag_sources_count
+        return output_data
+
 
 AgentFactory.register("optimized_enterprise_quality", OptimizedEnterpriseQualityAgent)

--- a/python_backend/api/feedback.py
+++ b/python_backend/api/feedback.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Request, status
-from schemas.feedback import UserFeedback
+from api.v1.schemas.quality import UserFeedbackRequest as UserFeedback
 from typing import Dict
 
 router = APIRouter(

--- a/python_backend/api/v1/endpoints/quality.py
+++ b/python_backend/api/v1/endpoints/quality.py
@@ -172,8 +172,8 @@ async def analyze_company_text_quality(
                     CompanySuggestionItem(
                         id=f"protocol_{i}",
                         category=sugg.get('category', 'protocol'),
-                        original=sugg.get('violation', sugg.get('rule', '')),
-                        suggestion=sugg.get('correction', sugg.get('suggestion', '')),
+                        original=sugg.get('original', ''),  # violation → original
+                        suggestion=sugg.get('suggestion', ''),  # correction → suggestion
                         reason=sugg.get('reason', '') or sugg.get('rule', ''),
                         severity=sugg.get('severity', 'medium')
                     )

--- a/python_backend/api/v1/endpoints/quality.py
+++ b/python_backend/api/v1/endpoints/quality.py
@@ -1,22 +1,15 @@
 """
 Text Quality Analysis Endpoints (기업용 확장)
-하드코딩 제거, 명확한 에러 처리
+Service Layer를 통한 명확한 계층 구조
 """
 
-# Standard library imports
 import json
 import logging
 import time
 from typing import Annotated, Dict, Any
-
-# Third-party imports
 from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks
-
-# Local imports - Core services
 from services.rag_service import RAGService
 from services.rewrite_service import rewrite_text
-
-# Local imports - Schemas
 from api.v1.schemas.quality import (
     CompanyQualityAnalysisRequest,
     CompanyQualityAnalysisResponse,
@@ -34,11 +27,11 @@ from api.v1.schemas.suggest import FeedbackItem
 
 # Conditional imports for enterprise features
 try:
-    from agents.quality_analysis_agent import OptimizedEnterpriseQualityAgent
-    ENTERPRISE_AGENT_AVAILABLE = True
+    from services.quality_analysis_service import OptimizedEnterpriseQualityService
+    ENTERPRISE_SERVICE_AVAILABLE = True
 except ImportError:
-    OptimizedEnterpriseQualityAgent = None
-    ENTERPRISE_AGENT_AVAILABLE = False
+    OptimizedEnterpriseQualityService = None
+    ENTERPRISE_SERVICE_AVAILABLE = False
 
 try:
     from services.enterprise_db_service import get_enterprise_db_service, EnterpriseDBService
@@ -61,17 +54,25 @@ def get_rag_service():
     return container.rag_service()
 
 
-def get_enterprise_quality_agent():
-    """기업용 품질분석 Agent 싱글톤 인스턴스 반환"""
-    if not ENTERPRISE_AGENT_AVAILABLE:
+def get_enterprise_quality_service():
+    """기업용 품질분석 Service 반환"""
+    if not ENTERPRISE_SERVICE_AVAILABLE:
         raise HTTPException(
             status_code=503,
-            detail="기업용 기능이 비활성화되어 있습니다. langgraph 의존성을 설치해주세요."
+            detail="기업용 기능이 비활성화되어 있습니다."
         )
-
+    
     from core.container import Container
     container = Container()
-    return container.enterprise_quality_agent()
+    service = container.enterprise_quality_service()
+    
+    if service is None:
+        raise HTTPException(
+            status_code=503,
+            detail="기업용 서비스를 초기화할 수 없습니다."
+        )
+    
+    return service
 
 
 async def get_enterprise_db_service_dep():
@@ -93,9 +94,10 @@ async def get_dropdown_options() -> DropdownOptions:
 @router.post("/company/analyze", response_model=CompanyQualityAnalysisResponse)
 async def analyze_company_text_quality(
     request: CompanyQualityAnalysisRequest,
-    agent: Annotated[object, Depends(get_enterprise_quality_agent)]
+    service: Annotated[OptimizedEnterpriseQualityService, Depends(get_enterprise_quality_service)]
 ) -> CompanyQualityAnalysisResponse:
-   
+    """기업용 텍스트 품질 분석 (Service Layer를 통한 호출)"""
+    
     start_time = time.time()
 
     try:
@@ -104,13 +106,14 @@ async def analyze_company_text_quality(
             f"대상: {request.target_audience.value}, 상황: {request.context.value}"
         )
 
-        # Agent 직접 호출
-        result = await agent.analyze_enterprise_quality(
+        # Service 호출 (Agent는 Service 내부에서 처리)
+        result = await service.analyze_enterprise_text(
             text=request.text,
             target_audience=request.target_audience.value,
             context=request.context.value,
             company_id=request.company_id,
-            user_id=request.user_id
+            user_id=request.user_id,
+            detailed=request.detailed
         )
         
         # 에러 체크
@@ -122,7 +125,7 @@ async def analyze_company_text_quality(
             if 'company' in error_msg.lower() or 'profile' in error_msg.lower():
                 raise HTTPException(
                     status_code=400,
-                    detail="기업 프로필 설정 필요"
+                    detail="기업 프로필 설정이 필요합니다"
                 )
             
             # 기타 에러는 500
@@ -131,7 +134,7 @@ async def analyze_company_text_quality(
                 detail=f"분석 실패: {error_msg}"
             )
         
-        # 점수 검증 (0점이면 분석 실패로 간주)
+        # 점수 검증
         grammar_score = result.get('grammar_score', 0.0)
         if grammar_score == 0.0:
             logger.error("분석 결과가 비어있음")
@@ -140,16 +143,14 @@ async def analyze_company_text_quality(
                 detail="분석 실패: 점수 계산 불가"
             )
         
-        # Agent 결과를 API 응답 형식으로 변환
+        # Service 결과를 API 응답 형식으로 변환
         response = CompanyQualityAnalysisResponse(
-            # 기본 점수들
             grammarScore=result['grammar_score'],
             formalityScore=result['formality_score'],
             readabilityScore=result['readability_score'],
             protocolScore=result['protocol_score'],
             complianceScore=result['compliance_score'],
             
-            # 섹션별 결과
             grammarSection=GrammarSection(
                 score=result['grammar_score'],
                 suggestions=[
@@ -180,12 +181,11 @@ async def analyze_company_text_quality(
                 ]
             ),
             
-            # 메타데이터
             companyAnalysis=CompanyAnalysis(
                 companyId=request.company_id,
                 communicationStyle=result.get('company_analysis', {}).get('communication_style', 'formal'),
                 complianceLevel=result['compliance_score'],
-                methodUsed=result.get('optimization_info', {}).get('analysis_method', 'comprehensive'),
+                methodUsed=result.get('method_used', 'unknown'),
                 processingTime=result.get('processing_time', 0.0),
                 ragSourcesCount=result.get('rag_sources_count', 0)
             )
@@ -193,7 +193,10 @@ async def analyze_company_text_quality(
         
         # 성능 로깅
         execution_time = time.time() - start_time
-        logger.info(f"기업용 분석 완료 - 실행시간: {execution_time:.2f}초")
+        logger.info(
+            f"기업용 분석 완료 - 실행시간: {execution_time:.2f}초, "
+            f"방법: {result.get('method_used', 'unknown')}"
+        )
 
         if execution_time > 5.0:
             logger.warning(
@@ -218,13 +221,13 @@ async def save_user_feedback(
     background_tasks: BackgroundTasks,
     db_service: Annotated[object, Depends(get_enterprise_db_service_dep)]
 ) -> UserFeedbackResponse:
+    """사용자 피드백 저장"""
     try:
         logger.info(
             f"사용자 피드백 저장 - 세션: {request.session_id}, "
             f"타입: {request.feedback_type.value}"
         )
         
-        # 피드백 데이터 구성
         feedback_data = {
             'user_id': request.user_id,
             'company_id': request.company_id,
@@ -241,7 +244,6 @@ async def save_user_feedback(
             }
         }
         
-        # 백그라운드에서 DB에 저장
         background_tasks.add_task(db_service.save_user_feedback, feedback_data)
         
         return UserFeedbackResponse(
@@ -261,16 +263,9 @@ async def save_user_feedback(
 
 @router.post("/company/generate-final", response_model=FinalTextGenerationResponse)
 async def generate_final_integrated_text(
-    request: FinalTextGenerationRequest,
-    agent: Annotated[object, Depends(get_enterprise_quality_agent)]
+    request: FinalTextGenerationRequest
 ) -> FinalTextGenerationResponse:
-    """
-    사용자 선택 기반 최종 통합본 생성 (AI 기반)
-    
-    테스트 케이스:
-    - FS-007 High: 제안 선택 → 200 + 반영된 최종본 + 적용 개수
-    - FS-007 Basic: 제안 선택 없음 → 200 + 원본 반환 + 적용 개수 0
-    """
+    """최종 통합본 생성 (rewrite_service 직접 호출)"""
     try:
         logger.info(
             f"최종 통합본 생성 시작 - 선택된 제안: "
@@ -278,8 +273,9 @@ async def generate_final_integrated_text(
             f"프로토콜 {len(request.selected_protocol_ids)}개"
         )
         
-        # 선택된 제안들을 rewrite_service가 요구하는 FeedbackItem 형식으로 변환
+        # 선택된 제안들을 FeedbackItem 형식으로 변환
         feedback_items = []
+        
         for sugg in request.grammar_suggestions:
             if sugg.id in request.selected_grammar_ids:
                 feedback_items.append(
@@ -316,6 +312,7 @@ async def generate_final_integrated_text(
                 message="적용할 제안이 선택되지 않았습니다."
             )
 
+        # rewrite_service로 최종 텍스트 생성
         rewrite_result = rewrite_text(
             text=request.original_text,
             traits={},
@@ -353,14 +350,12 @@ async def get_company_setup_status(
 ) -> Dict[str, Any]:
     """기업 설정 상태 확인"""
     try:
-        # DB에서 기업 정보 조회
         profile = await db_service.get_company_profile(company_id)
         guidelines = await db_service.get_company_guidelines(company_id)
         
         profile_exists = profile is not None
         guidelines_count = len(guidelines) if guidelines else 0
         
-        # 상태 결정
         if profile_exists and guidelines_count > 0:
             status = "ready"
         elif profile_exists:
@@ -393,13 +388,11 @@ async def create_test_company_setup(
     company_id: str,
     db_service: Annotated[EnterpriseDBService, Depends(get_enterprise_db_service_dep)]
 ) -> Dict[str, Any]:
-    """테스트용 기업 설정 생성 (개발/테스트용)"""
+    """테스트용 기업 설정 생성"""
     try:
-        # 테스트 회사 데이터 생성
         success = await db_service.create_test_company(company_id)
         
         if success:
-            # 상태 확인
             profile = await db_service.get_company_profile(company_id)
             guidelines = await db_service.get_company_guidelines(company_id)
             

--- a/python_backend/api/v1/endpoints/quality.py
+++ b/python_backend/api/v1/endpoints/quality.py
@@ -1,18 +1,38 @@
 """
-Text Quality Analysis Endpoints (기업용 확장) - 수정된 버전
-Agent를 직접 사용하여 서비스 중복 제거
+Text Quality Analysis Endpoints (기업용 확장)
+하드코딩 제거, 명확한 에러 처리
 """
 
-from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks
+# Standard library imports
 import json
 import logging
+import time
 from typing import Annotated, Dict, Any
 
-# 수정된 imports - 존재하는 모듈들만 import
-from services.rag_service import RAGService
-# from services.enterprise_db_service import get_enterprise_db_service, EnterpriseDBService  # asyncpg 의존성 문제
+# Third-party imports
+from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks
 
-# langgraph 의존성 문제 해결을 위한 조건부 import
+# Local imports - Core services
+from services.rag_service import RAGService
+from services.rewrite_service import rewrite_text
+
+# Local imports - Schemas
+from api.v1.schemas.quality import (
+    CompanyQualityAnalysisRequest,
+    CompanyQualityAnalysisResponse,
+    UserFeedbackRequest,
+    UserFeedbackResponse,
+    FinalTextGenerationRequest,
+    FinalTextGenerationResponse,
+    CompanySuggestionItem,
+    GrammarSection,
+    ProtocolSection,
+    CompanyAnalysis,
+    DropdownOptions
+)
+from api.v1.schemas.suggest import FeedbackItem
+
+# Conditional imports for enterprise features
 try:
     from agents.quality_analysis_agent import OptimizedEnterpriseQualityAgent
     ENTERPRISE_AGENT_AVAILABLE = True
@@ -27,32 +47,22 @@ except ImportError:
     get_enterprise_db_service = None
     EnterpriseDBService = None
     ENTERPRISE_DB_AVAILABLE = False
-from api.v1.schemas.quality import (
-    CompanyQualityAnalysisRequest,
-    CompanyQualityAnalysisResponse,
-    UserFeedbackRequest,
-    UserFeedbackResponse,
-    FinalTextGenerationRequest,
-    FinalTextGenerationResponse,
-    CompanySuggestionItem,
-    GrammarSection,
-    ProtocolSection,
-    CompanyAnalysis,
-    DropdownOptions
-)
 
+# Logger setup
 logger = logging.getLogger('chattoner')
 router = APIRouter()
 
-# 컨테이너에서 싱글톤 서비스들 가져오기
+
+# Dependency injection functions
 def get_rag_service():
     """RAG 서비스 싱글톤 인스턴스 반환"""
     from core.container import Container
     container = Container()
     return container.rag_service()
 
+
 def get_enterprise_quality_agent():
-    """기업용 품질분석 Agent 싱글톤 인스턴스 반환 (성능 최적화)"""
+    """기업용 품질분석 Agent 싱글톤 인스턴스 반환"""
     if not ENTERPRISE_AGENT_AVAILABLE:
         raise HTTPException(
             status_code=503,
@@ -63,35 +73,38 @@ def get_enterprise_quality_agent():
     container = Container()
     return container.enterprise_quality_agent()
 
-def get_enterprise_db_service_dep():
+
+async def get_enterprise_db_service_dep():
     """기업용 DB 서비스 의존성"""
     if not ENTERPRISE_DB_AVAILABLE:
         raise HTTPException(
             status_code=503,
             detail="기업용 DB 기능이 비활성화되어 있습니다. asyncpg 의존성을 설치해주세요."
         )
-    return get_enterprise_db_service()
+    return await get_enterprise_db_service()
+
 
 @router.get("/company/options", response_model=DropdownOptions)
 async def get_dropdown_options() -> DropdownOptions:
     """프론트엔드 드롭다운 옵션 제공"""
     return DropdownOptions()
 
+
 @router.post("/company/analyze", response_model=CompanyQualityAnalysisResponse)
 async def analyze_company_text_quality(
     request: CompanyQualityAnalysisRequest,
     agent: Annotated[object, Depends(get_enterprise_quality_agent)]
 ) -> CompanyQualityAnalysisResponse:
-    """기업용 텍스트 품질 분석 (문법 + 프로토콜 분석) - 성능 최적화 적용"""
-
-    # 성능 측정 시작
-    import time
+   
     start_time = time.time()
 
     try:
-        logger.info(f"기업용 품질분석 시작 - 회사: {request.company_id}, 대상: {request.target_audience.value}, 상황: {request.context.value}")
+        logger.info(
+            f"기업용 품질분석 시작 - 회사: {request.company_id}, "
+            f"대상: {request.target_audience.value}, 상황: {request.context.value}"
+        )
 
-        # Agent 직접 호출 (싱글톤으로 그래프 재사용)
+        # Agent 직접 호출
         result = await agent.analyze_enterprise_quality(
             text=request.text,
             target_audience=request.target_audience.value,
@@ -100,22 +113,45 @@ async def analyze_company_text_quality(
             user_id=request.user_id
         )
         
+        # 에러 체크
         if result.get('error'):
-            logger.warning(f"기업용 분석 중 경고: {result['error']}")
+            error_msg = result.get('error')
+            logger.error(f"분석 실패: {error_msg}")
+            
+            # 기업 프로필 관련 에러는 400
+            if 'company' in error_msg.lower() or 'profile' in error_msg.lower():
+                raise HTTPException(
+                    status_code=400,
+                    detail="기업 프로필 설정 필요"
+                )
+            
+            # 기타 에러는 500
+            raise HTTPException(
+                status_code=500,
+                detail=f"분석 실패: {error_msg}"
+            )
         
-        # @@ 하드코딩된 기본값 60.0: 더 적절한 기본값 및 계산 로직 필요
+        # 점수 검증 (0점이면 분석 실패로 간주)
+        grammar_score = result.get('grammar_score', 0.0)
+        if grammar_score == 0.0:
+            logger.error("분석 결과가 비어있음")
+            raise HTTPException(
+                status_code=500,
+                detail="분석 실패: 점수 계산 불가"
+            )
+        
         # Agent 결과를 API 응답 형식으로 변환
         response = CompanyQualityAnalysisResponse(
             # 기본 점수들
-            grammarScore=result.get('grammar_score', 60.0),
-            formalityScore=result.get('formality_score', 60.0),
-            readabilityScore=result.get('readability_score', 60.0),
-            protocolScore=result.get('protocol_score', 60.0),
-            complianceScore=result.get('compliance_score', 60.0),
+            grammarScore=result['grammar_score'],
+            formalityScore=result['formality_score'],
+            readabilityScore=result['readability_score'],
+            protocolScore=result['protocol_score'],
+            complianceScore=result['compliance_score'],
             
             # 섹션별 결과
             grammarSection=GrammarSection(
-                score=result.get('grammar_score', 60.0),
+                score=result['grammar_score'],
                 suggestions=[
                     CompanySuggestionItem(
                         id=f"grammar_{i}",
@@ -129,8 +165,8 @@ async def analyze_company_text_quality(
                 ]
             ),
             
-                        protocolSection=ProtocolSection(
-                score=result.get('protocol_score', 60.0),
+            protocolSection=ProtocolSection(
+                score=result['protocol_score'],
                 suggestions=[
                     CompanySuggestionItem(
                         id=f"protocol_{i}",
@@ -148,7 +184,7 @@ async def analyze_company_text_quality(
             companyAnalysis=CompanyAnalysis(
                 companyId=request.company_id,
                 communicationStyle=result.get('company_analysis', {}).get('communication_style', 'formal'),
-                complianceLevel=result.get('compliance_score', 60.0),
+                complianceLevel=result['compliance_score'],
                 methodUsed=result.get('optimization_info', {}).get('analysis_method', 'comprehensive'),
                 processingTime=result.get('processing_time', 0.0),
                 ragSourcesCount=result.get('rag_sources_count', 0)
@@ -159,16 +195,22 @@ async def analyze_company_text_quality(
         execution_time = time.time() - start_time
         logger.info(f"기업용 분석 완료 - 실행시간: {execution_time:.2f}초")
 
-        # 성능 경고 (5초 이상 소요시)
         if execution_time > 5.0:
-            logger.warning(f"느린 품질분석 호출 감지: {execution_time:.2f}초 (텍스트 길이: {len(request.text)})")
+            logger.warning(
+                f"느린 품질분석 호출 감지: {execution_time:.2f}초 "
+                f"(텍스트 길이: {len(request.text)})"
+            )
 
         return response
 
+    except HTTPException:
+        raise
+    
     except Exception as e:
         execution_time = time.time() - start_time
-        logger.error(f"기업용 품질분석 실패 ({execution_time:.2f}초): {str(e)}")
+        logger.error(f"기업용 품질분석 실패 ({execution_time:.2f}초): {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"기업용 품질분석 실패: {str(e)}")
+
 
 @router.post("/company/feedback", response_model=UserFeedbackResponse)
 async def save_user_feedback(
@@ -176,10 +218,11 @@ async def save_user_feedback(
     background_tasks: BackgroundTasks,
     db_service: Annotated[object, Depends(get_enterprise_db_service_dep)]
 ) -> UserFeedbackResponse:
-    """사용자 피드백 저장 (good/bad 선택)"""
-    
     try:
-        logger.info(f"사용자 피드백 저장 - 세션: {request.session_id}, 타입: {request.feedback_type.value}")
+        logger.info(
+            f"사용자 피드백 저장 - 세션: {request.session_id}, "
+            f"타입: {request.feedback_type.value}"
+        )
         
         # 피드백 데이터 구성
         feedback_data = {
@@ -215,49 +258,69 @@ async def save_user_feedback(
             session_id=request.session_id
         )
 
+
 @router.post("/company/generate-final", response_model=FinalTextGenerationResponse)
 async def generate_final_integrated_text(
     request: FinalTextGenerationRequest,
     agent: Annotated[object, Depends(get_enterprise_quality_agent)]
 ) -> FinalTextGenerationResponse:
-    """사용자 선택 기반 최종 통합본 생성 (AI 기반)"""
-    # Local imports for self-contained replacement
-    from services.rewrite_service import rewrite_text
-    from api.v1.schemas.suggest import FeedbackItem
-
+    """
+    사용자 선택 기반 최종 통합본 생성 (AI 기반)
+    
+    테스트 케이스:
+    - FS-007 High: 제안 선택 → 200 + 반영된 최종본 + 적용 개수
+    - FS-007 Basic: 제안 선택 없음 → 200 + 원본 반환 + 적용 개수 0
+    """
     try:
-        logger.info(f"최종 통합본 생성 시작 - 선택된 제안: 문법 {len(request.selected_grammar_ids)}개, 프로토콜 {len(request.selected_protocol_ids)}개")
+        logger.info(
+            f"최종 통합본 생성 시작 - 선택된 제안: "
+            f"문법 {len(request.selected_grammar_ids)}개, "
+            f"프로토콜 {len(request.selected_protocol_ids)}개"
+        )
         
         # 선택된 제안들을 rewrite_service가 요구하는 FeedbackItem 형식으로 변환
         feedback_items = []
         for sugg in request.grammar_suggestions:
             if sugg.id in request.selected_grammar_ids:
                 feedback_items.append(
-                    FeedbackItem(id=sugg.id, type="grammar", before=sugg.original, after=sugg.suggestion)
+                    FeedbackItem(
+                        id=sugg.id,
+                        type="grammar",
+                        before=sugg.original,
+                        after=sugg.suggestion
+                    )
                 )
         
         for sugg in request.protocol_suggestions:
             if sugg.id in request.selected_protocol_ids:
                 feedback_items.append(
-                    FeedbackItem(id=sugg.id, type="protocol", before=sugg.original, after=sugg.suggestion)
+                    FeedbackItem(
+                        id=sugg.id,
+                        type="protocol",
+                        before=sugg.original,
+                        after=sugg.suggestion
+                    )
                 )
 
         if not feedback_items:
             return FinalTextGenerationResponse(
                 success=True,
                 finalText=request.original_text,
-                appliedSuggestions={'grammarCount': 0, 'protocolCount': 0, 'totalApplied': 0},
+                appliedSuggestions={
+                    'grammarCount': 0,
+                    'protocolCount': 0,
+                    'totalApplied': 0
+                },
                 originalLength=len(request.original_text),
                 finalLength=len(request.original_text),
                 message="적용할 제안이 선택되지 않았습니다."
             )
 
-        # rewrite_service를 사용하여 제안 사항들을 안정적으로 적용
-        # 이 서비스는 단순 치환이 아닌, 문맥을 고려한 수정을 수행합니다.
         rewrite_result = rewrite_text(
             text=request.original_text,
+            traits={},
             feedback=[fb.model_dump() for fb in feedback_items],
-            options={"strict_policy": True} # 제안된 내용을 최대한 반영하도록 옵션 설정
+            options={"strict_policy": True}
         )
 
         final_text = rewrite_result.get("revised_text", request.original_text)
@@ -277,7 +340,11 @@ async def generate_final_integrated_text(
         
     except Exception as e:
         logger.error(f"최종 통합본 생성 중 오류: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"최종 통합본 생성 중 서버 오류 발생: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"최종 통합본 생성 중 서버 오류 발생: {e}"
+        )
+
 
 @router.get("/company/{company_id}/status")
 async def get_company_setup_status(
@@ -285,7 +352,6 @@ async def get_company_setup_status(
     db_service: Annotated[object, Depends(get_enterprise_db_service_dep)]
 ) -> Dict[str, Any]:
     """기업 설정 상태 확인"""
-    
     try:
         # DB에서 기업 정보 조회
         profile = await db_service.get_company_profile(company_id)
@@ -321,13 +387,13 @@ async def get_company_setup_status(
             "ready_for_analysis": False
         }
 
+
 @router.post("/company/test-setup")
 async def create_test_company_setup(
-    company_id: str = "test_company",
-    db_service: Annotated[object, Depends(get_enterprise_db_service_dep)] = None
+    company_id: str,
+    db_service: Annotated[EnterpriseDBService, Depends(get_enterprise_db_service_dep)]
 ) -> Dict[str, Any]:
     """테스트용 기업 설정 생성 (개발/테스트용)"""
-    
     try:
         # 테스트 회사 데이터 생성
         success = await db_service.create_test_company(company_id)

--- a/python_backend/api/v1/schemas/quality.py
+++ b/python_backend/api/v1/schemas/quality.py
@@ -190,14 +190,6 @@ class DropdownOptions(BaseModel):
         description="상황 선택 옵션들"
     )
 
-# 에러 응답 스키마
-class CompanyErrorResponse(BaseModel):
-    """기업용 에러 응답"""
-    error: str = Field(..., description="에러 메시지")
-    error_code: Optional[str] = Field(None, description="에러 코드")
-    details: Optional[Dict[str, Any]] = Field(None, description="상세 정보")
-    fallback_available: bool = Field(default=True, description="fallback 이용 가능 여부")
-
 # 개발/테스트용 스키마들
 class AnalysisDebugInfo(BaseModel):
     """분석 디버그 정보"""

--- a/python_backend/core/container.py
+++ b/python_backend/core/container.py
@@ -16,7 +16,8 @@ from services.rag_service import RAGService
 # 선택적 import (의존성이 있을 때만)
 try:
     from agents.quality_analysis_agent import OptimizedEnterpriseQualityAgent
-    from services.enterprise_db_service import EnterpriseDBService
+    from services.enterprise_db_service import EnterpriseDBService, get_enterprise_db_service
+    from services.quality_analysis_service import OptimizedEnterpriseQualityService
     ENTERPRISE_FEATURES_AVAILABLE = True
 except ImportError as e:
     # @@ langgraph 의존성 설치 필요: pip install langgraph
@@ -76,4 +77,10 @@ class Container(containers.DeclarativeContainer):
             OptimizedEnterpriseQualityAgent,
             rag_service=rag_service,
             db_service=enterprise_db_service
+        )
+
+        # 기업용 품질분석 서비스
+        enterprise_quality_service = providers.Factory(
+            OptimizedEnterpriseQualityService,
+            rag_service=rag_service
         )

--- a/python_backend/core/container.py
+++ b/python_backend/core/container.py
@@ -80,7 +80,7 @@ class Container(containers.DeclarativeContainer):
         )
 
         # 기업용 품질분석 서비스
-        enterprise_quality_service = providers.Factory(
+        enterprise_quality_service = providers.Singleton(
             OptimizedEnterpriseQualityService,
             rag_service=rag_service
         )

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -21,7 +21,7 @@ from core.container import Container
 from core.middleware import setup_middleware
 from core.exception_handlers import setup_exception_handlers
 from api.v1.router import api_router
-from starlette.middleware.session import SessionMiddleware
+from starlette.middleware.sessions import SessionMiddleware
 from api import feedback
 
 FRONT_ORIGINS = [
@@ -48,7 +48,9 @@ def create_app() -> FastAPI:
         "api.v1.endpoints.health",
         "api.v1.endpoints.profile",
         "api.v1.endpoints.feedback",
-        "api.v1.endpoints.rag"
+        "api.v1.endpoints.rag",
+        "api.v1.endpoints.quality",
+        "api.v1.endpoints.company"
         # @@ quality와 company는 langgraph/enterprise 의존성 문제로 제외됨. 추가 필요!!!
     ])
     

--- a/python_backend/utils/quality_analysis_llm.py
+++ b/python_backend/utils/quality_analysis_llm.py
@@ -1,0 +1,123 @@
+"""
+LLM-based suggestion generation
+- Uses both Agent and Service
+- Unified prompt and parsing
+"""
+import logging
+import json
+import re
+from typing import Dict, Any, List, Optional
+from utils.quality_analysis_utils import summarize_issues, create_basic_suggestions
+
+logger = logging.getLogger('chattoner.quality_analysis_llm')
+
+
+async def generate_suggestions_with_llm(
+    rag_service,
+    text: str,
+    rewrite_result: dict,
+    target_audience: str,
+    context: str,
+    company_profile: Optional[Dict[str, Any]] = None,
+    max_grammar: int = 5,
+    max_protocol: int = 5
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Generate concrete suggestions with an LLM.
+
+    Args:
+        rag_service: RAG service.
+        text: Original text.
+        rewrite_result: Result from rewrite_text().
+        target_audience: Target audience.
+        context: Context of use.
+        company_profile: Company profile (optional).
+        max_grammar: Maximum number of grammar suggestions.
+        max_protocol: Maximum number of protocol suggestions.
+
+    Returns:
+        {"grammar": [...], "protocol": [...]}
+    """
+
+
+    
+    grammar = rewrite_result.get("grammar", {})
+    protocol = rewrite_result.get("protocol", {})
+    issues_summary = summarize_issues(grammar, protocol)
+    company_style = company_profile.get("communication_style", "formal") if company_profile else "formal"
+    prompt = f"""다음 텍스트의 문제점을 기반으로 구체적인 수정 제안을 생성해주세요.
+
+원문:
+{text[:300]}{"..." if len(text) > 300 else ""}
+
+대상: {target_audience}
+상황: {context}
+기업 스타일: {company_style}
+
+감지된 문제:
+{issues_summary}
+
+다음 JSON 형식으로만 응답:
+{{
+    "grammar_suggestions": [
+        {{
+            "original": "원문에서 문제 있는 구체적 표현",
+            "suggestion": "수정된 표현",
+            "reason": "수정 이유"
+        }}
+    ],
+    "protocol_suggestions": [
+        {{
+            "original": "위반 표현",
+            "suggestion": "수정 방안",
+            "reason": "위반 이유 설명",
+            "severity": "high|medium|low"
+        }}
+    ]
+}}
+
+최대 5개씩만 제안하세요."""
+    
+    # LLM call
+    try:
+        result = await rag_service.ask_generative_question(
+            query=prompt,
+            context="기업 텍스트 개선 제안"
+        )
+        
+        if result and result.get("success"):
+            # JSON parsing
+            json_match = re.search(r'\{[\s\S]*\}', result["answer"])
+            if json_match:
+                suggestions_data = json.loads(json_match.group())
+            else:
+                suggestions_data = json.loads(result["answer"])
+            
+            # Formatting
+            return {
+                "grammar": [
+                    {
+                        "category": "문법",
+                        "original": s.get("original", ""),
+                        "suggestion": s.get("suggestion", ""),
+                        "reason": s.get("reason", "")
+                    }
+                    for s in suggestions_data.get("grammar_suggestions", [])[:max_grammar]
+                ],
+                "protocol": [
+                    {
+                        "category": "프로토콜",
+                        "original": s.get("original", ""),          # violation → original
+                        "suggestion": s.get("suggestion", ""),      # correction → suggestion
+                        "reason": s.get("reason", ""),
+                        "severity": s.get("severity", "medium")
+                    }
+                    for s in suggestions_data.get("protocol_suggestions", [])[:max_protocol]
+                ]
+            }
+    
+    except Exception as e:
+        logger.error(f"LLM 제안 생성 실패: {e}")
+    
+    # Default suggestions on LLM failure
+    return create_basic_suggestions(rewrite_result)

--- a/python_backend/utils/quality_analysis_utils.py
+++ b/python_backend/utils/quality_analysis_utils.py
@@ -1,0 +1,227 @@
+"""
+Quality analysis utility functions
+- Score extraction/calculation
+- Mapping functions
+- Generate default suggestions
+"""
+from typing import Dict, Any, List, Tuple, Optional
+
+
+# ============ Extracting scores ============
+
+def extract_formality_score(grammar: dict) -> float:
+    """Formality score extraction"""
+    korean_endings = grammar.get("korean_endings", {})
+    if korean_endings.get("ending_ok"):
+        return 85.0
+    
+    speech_map = {
+        "합쇼체": 80.0,
+        "해요체": 75.0,
+        "의문형": 78.0,
+        "평서/반말": 60.0
+    }
+    return speech_map.get(korean_endings.get("speech_level"), 65.0)
+
+
+def extract_readability_score(grammar: dict) -> float:
+    """Readability score extraction"""
+    avg_len = grammar.get("metrics", {}).get("avg_sentence_len", 30)
+    if avg_len < 20:
+        return 90.0
+    if avg_len < 30:
+        return 85.0
+    if avg_len < 50:
+        return 75.0
+    if avg_len < 80:
+        return 65.0
+    return 55.0
+
+
+def extract_base_scores(rewrite_result: dict) -> dict:
+    """Extract default scores from rewrite results"""
+    grammar = rewrite_result.get("grammar", {})
+    protocol = rewrite_result.get("protocol", {})
+    
+    return {
+        "grammar_score": grammar.get("metrics", {}).get("grammar_score", 70.0),
+        "formality_score": extract_formality_score(grammar),
+        "readability_score": extract_readability_score(grammar),
+        "protocol_score": protocol.get("metrics", {}).get("policy_score", 0.7) * 100
+    }
+
+
+# ============ Expectation-Gap  ============
+
+def apply_expectation_gap(
+    base_scores: dict,
+    company_profile: Optional[dict]
+) -> Tuple[dict, dict]:
+    """
+    Adjust scores based on company expectations.
+
+    Args:
+        base_scores: Dict of base scores.
+        company_profile: Company profile (no adjustment if None).
+
+    Returns:
+        (adjusted_scores, adjustment_info)
+    """
+    if not company_profile:
+        return base_scores, {"adjusted": False}
+    
+    company_style = company_profile.get("communication_style", "formal")
+    expectations = {
+        "strict": {"formality": 90, "protocol": 85},
+        "formal": {"formality": 80, "protocol": 75},
+        "friendly": {"formality": 70, "protocol": 65}
+    }
+    expected = expectations.get(company_style, expectations["formal"])
+    
+    formality_gap = max(0, expected["formality"] - base_scores["formality_score"])
+    protocol_gap = max(0, expected["protocol"] - base_scores["protocol_score"])
+    
+    formality_penalty = formality_gap * 0.2
+    protocol_penalty = protocol_gap * 0.3
+    
+    adjusted = {
+        "grammar_score": base_scores["grammar_score"],
+        "formality_score": max(0, base_scores["formality_score"] - formality_penalty),
+        "readability_score": base_scores["readability_score"],
+        "protocol_score": max(0, base_scores["protocol_score"] - protocol_penalty)
+    }
+    
+    adjustment_info = {
+        "adjusted": True,
+        "company_style": company_style,
+        "expected": expected,
+        "gaps": {"formality_gap": formality_gap, "protocol_gap": protocol_gap},
+        "penalties": {"formality_penalty": formality_penalty, "protocol_penalty": protocol_penalty}
+    }
+    
+    return adjusted, adjustment_info
+
+
+# ============ mapping ============
+
+def map_audience(target: str) -> List[str]:
+    """target → audience"""
+    mapping = {
+        "직속상사": ["executives"],
+        "팀동료": ["team"],
+        "타부서담당자": ["team"],
+        "클라이언트": ["clients_vendors"],
+        "외부협력업체": ["clients_vendors"],
+        "후배신입": ["team"]
+    }
+    return mapping.get(target, ["team"])
+
+
+def map_channel(context: str) -> str:
+    """context → channel"""
+    mapping = {
+        "보고서": "report",
+        "회의록": "meeting_minutes",
+        "이메일": "email",
+        "공지사항": "email",
+        "메시지": "chat"
+    }
+    return mapping.get(context, "email")
+
+
+# ============ Issues  ============
+
+def summarize_issues(grammar: dict, protocol: dict) -> str:
+    """Summarize analysis results for the LLM"""
+    issues = []
+    
+    grammar_score = grammar.get("metrics", {}).get("grammar_score")
+    if grammar_score is not None and grammar_score < 70:
+        issues.append(f"- 전반적 문법 점수 낮음 ({grammar_score:.0f}점)")
+    
+    korean_endings = grammar.get("korean_endings", {})
+    if not korean_endings.get("ending_ok"):
+        issues.append(f"- 어미 격식: {korean_endings.get('speech_level', '부적절')}")
+    
+    banned = protocol.get("flags", {}).get("banned_terms", [])
+    if banned:
+        issues.append(f"- 금칙어 사용: {', '.join(banned[:3])}")
+    
+    missing = protocol.get("details", {}).get("missing_sections", [])
+    if missing:
+        issues.append(f"- 필수 섹션 누락: {', '.join(missing[:2])}")
+    
+    avg_len = grammar.get("metrics", {}).get("avg_sentence_len", 0)
+    if avg_len > 50:
+        issues.append(f"- 문장이 너무 김 (평균 {avg_len}자)")
+    
+    emoji_count = grammar.get("word_flags", {}).get("emoji_used", 0)
+    if emoji_count > 0:
+        issues.append(f"- 이모지 사용 ({emoji_count}개)")
+    
+    return "\n".join(issues) if issues else "주요 문제점 없음"
+
+
+# ============ Generate default suggestions ============
+
+def create_basic_suggestions(rewrite_result: dict) -> dict:
+    """Generate default suggestions without an LLM"""
+    protocol = rewrite_result.get("protocol", {})
+    
+    suggestions = {
+        "grammar": [],
+        "protocol": []
+    }
+    
+    banned = protocol.get("flags", {}).get("banned_terms", [])
+    for term in banned[:3]:
+        suggestions["protocol"].append({
+            "category": "프로토콜",
+            "original": term,                           # violation → original
+            "suggestion": "대체 표현 사용 필요",          # correction → suggestion
+            "reason": "금칙어 사용 - 기업 정책 위반",
+            "severity": "high"
+        })
+    
+    missing = protocol.get("details", {}).get("missing_sections", [])
+    for section in missing[:2]:
+        suggestions["protocol"].append({
+            "category": "프로토콜",
+            "original": f"[{section} 섹션]",
+            "suggestion": f"{section} 섹션 추가 권장",    # correction → suggestion
+            "reason": f"필수 섹션 누락 - {section} 필요",
+            "severity": "medium"
+        })
+    
+    if not protocol.get("flags", {}).get("tone_consistent", True):
+        suggestions["grammar"].append({
+            "category": "톤",
+            "original": "[전체 텍스트]",
+            "suggestion": "격식 있는 표현으로 통일",
+            "reason": "톤 일관성 - 비즈니스 커뮤니케이션 톤 유지"
+        })
+    
+    return suggestions
+
+
+# ============ Improvement priority ============
+
+def determine_improvement_priority(scores: dict) -> List[str]:
+    """Score-based improvement prioritization"""
+    priorities = []
+    
+    if scores.get("protocol_score", 70) < 70:
+        priorities.append("기업 프로토콜 준수")
+    if scores.get("formality_score", 70) < 70:
+        priorities.append("격식도 조정")
+    if scores.get("grammar_score", 70) < 70:
+        priorities.append("문법 개선")
+    if scores.get("readability_score", 70) < 70:
+        priorities.append("가독성 향상")
+    
+    return priorities or ["전반적 품질 향상"]
+
+
+def identify_concerns(scores: dict) -> List[str]:
+    """주요 개선점 식별 (determine_improvement_priority의 별칭)"""
+    return determine_improvement_priority(scores)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,12 @@ python-multipart>=0.0.6
 dependency-injector>=4.41.0
 sqlalchemy>=2.0.42
 psycopg2-binary>=2.9.9
+alembic>=1.13.1
 pypdf>=4.2.0
 langchain>=0.1.0
 langchain-community>=0.0.10
 langchain-text-splitters>=0.0.1
+langgraph>=0.0.30
 faiss-cpu>=1.7.4
 
 # Testing dependencies


### PR DESCRIPTION
# Summary
기업용 품질분석 Agent의 안정성과 유지보수성을 개선하기 위한 대규모 리팩토링입니다. Agent 실패 시 Service Layer Fallback 구조를 도입하고, 공통 로직을 유틸리티 함수로 분리했습니다.

# 주요 변경사항
## 1. Agent 내부 Fallback 메커니즘 추가

- 변경 전: RAG 실패 시 전체 분석 실패
- 변경 후: RAG 실패 → Agent 내부 Fallback (규칙 기반 + 선택적 LLM)
```python
# python: agents/quality_analysis_agent.py
async def _comprehensive_analysis(state):
    # RAG 시도
    result = await self._call_rag_with_retry(...)
    
    if result:
        try:
            # RAG 성공 시 파싱
            analysis_data = self._extract_json_from_text(result["answer"])
            state["processing_metadata"]["analysis_method"] = "rag_comprehensive"
            return state
        except (ValueError, json.JSONDecodeError) as e:
            logger.warning(f"JSON 파싱 실패: {e}, Agent 내부 fallback 시작")
    else:
        logger.warning("RAG 호출 실패, Agent 내부 fallback 시작")
    
    # Agent 내부 fallback 실행
    return await self._agent_internal_fallback(state)
```
### 주요 특징
- 이미 로드된 company_profile 재사용 (DB 중복 조회 방지)
- rewrite_service + 규칙 기반 점수 계산
- 설정(enable_llm_fallback)에 따라 LLM 제안 생성 가능

## 2. Service Layer Fallback 구조
- 변경 전: Agent 초기화 실패 시 에러 반환
- 변경 후: Agent 초기화 실패 → Service가 전체 분석 수행
###Fallback 수행 작업:
- 기업 프로필 새로 로드 (db_service 사용)
- rewrite_text로 기본 분석 수행
- apply_expectation_gap으로 기업 맥락 점수 조정
- 설정에 따라 LLM 제안 생성 (enable_llm_in_fallback)

## 3. utils/quality_analysis_utils.py
```python
# 점수 추출
extract_base_scores(rewrite_result) -> dict
extract_formality_score(grammar) -> float
extract_readability_score(grammar) -> float

# 기업 맥락 반영
apply_expectation_gap(base_scores, company_profile) -> (adjusted_scores, adjustment_info)

# 매핑 함수
map_audience(target: str) -> List[str]  # "직속상사" → ["executives"]
map_channel(context: str) -> str        # "이메일" → "email"

# 분석 헬퍼
summarize_issues(grammar, protocol) -> str
identify_concerns(scores) -> List[str]
determine_improvement_priority(scores) -> List[str]

# 기본 제안 생성
create_basic_suggestions(rewrite_result) -> dict
```
## 4. utils/quality_analysis_llm.py
```python
# 점수 추출
extract_base_scores(rewrite_result) -> dict
extract_formality_score(grammar) -> float
extract_readability_score(grammar) -> float

# 기업 맥락 반영
apply_expectation_gap(base_scores, company_profile) -> (adjusted_scores, adjustment_info)

# 매핑 함수
map_audience(target: str) -> List[str]  # "직속상사" → ["executives"]
map_channel(context: str) -> str        # "이메일" → "email"

# 분석 헬퍼
summarize_issues(grammar, protocol) -> str
identify_concerns(scores) -> List[str]
determine_improvement_priority(scores) -> List[str]

# 기본 제안 생성
create_basic_suggestions(rewrite_result) -> dict
```
- 유틸함수들은 agent와 service에서 동일한 로직을 재사용합니다.

## 5. rewrite_service 확장
 ### analysis_only=True 모드 추가
- 텍스트 수정 없이 분석만 수행
- Fallback에서 안전하게 사용 가능
- 기존 로직 변경 없이 호환성 유지

## 6. api ->service -> agent 계층 명확화
```
api/v1/endpoints/quality.py (API Layer)
    ↓ Depends(get_enterprise_quality_service)
services/quality_analysis_service.py (Service Layer)
    ↓ Agent 초기화 성공 시
agents/quality_analysis_agent.py (Agent Layer)
    ↓ RAG 실패 시
Agent 내부 Fallback (utils 활용)
```
# 개발자들 공유할 사항들
## api 변경사항
```python
# api/v1/endpoints/quality.py
@router.post("/company/analyze")
async def analyze_company_text_quality(
    request: CompanyQualityAnalysisRequest,
    service: Annotated[OptimizedEnterpriseQualityService, Depends(get_enterprise_quality_service)]
):
    result = await service.analyze_enterprise_text(...)
    
    # 에러 처리 개선
    if result.get('error'):
        error_msg = result.get('error')
        if 'company' in error_msg.lower() or 'profile' in error_msg.lower():
            raise HTTPException(status_code=400, detail="기업 프로필 설정이 필요합니다")
        raise HTTPException(status_code=500, detail=f"분석 실패: {error_msg}")
    
    # 점수 검증
    if result.get('grammar_score', 0.0) == 0.0:
        raise HTTPException(status_code=500, detail="분석 실패: 점수 계산 불가")
```
## 제안사항 필드 통일
``` python
# 변경 전 (Protocol)
{
    "rule": "위반된 규칙",
    "violation": "위반 내용",
    "correction": "수정 방안"
}

# 변경 후 (통일)
{
    "category": "프로토콜",
    "original": "위반 표현",      # violation → original
    "suggestion": "수정 방안",    # correction → suggestion
    "reason": "위반 이유"
}
```
# 기타 사항
## fallback flow 전체 흐름
```
1. API Request
   ↓
2. Service.analyze_enterprise_text()
   ↓
3. Agent 초기화 확인
   ├─ Agent 있음 → Agent.analyze_enterprise_quality()
   │   ├─ RAG 성공 → JSON 파싱 성공 → ✅ 반환
   │   ├─ RAG 성공 → JSON 파싱 실패 → Agent 내부 Fallback
   │   └─ RAG 실패 → Agent 내부 Fallback
   │       ↓
   │   [Agent 내부 Fallback]
   │   - 이미 로드된 company_profile 재사용
   │   - rewrite_text(analysis_only=True)
   │   - apply_expectation_gap()
   │   - generate_suggestions_with_llm() (옵션)
   │   → ✅ 반환 (method: "agent_fallback")
   │
   └─ Agent 없음 → Service Fallback
       ↓
   [Service Fallback]
   - company_profile 새로 로드 (DB 조회)
   - rewrite_text(analysis_only=True)
   - apply_expectation_gap()
   - generate_suggestions_with_llm() (옵션)
   → ✅ 반환 (method: "service_fallback_with_llm" or "service_fallback_basic")
```
## 메서드 식별 방법
- rag_comprehensive: RAG로 통합 분석 성공 (최상의 품질)
- agent_fallback: Agent 내부 fallback (규칙 기반 + 선택적 LLM)
- service_fallback_with_llm: Service fallback + LLM 제안 생성
- service_fallback_basic: Service fallback (규칙 기반만)
- system_error: 완전 실패 (모든 fallback 실패)
