### PR TITLE
feat: align gateway proxy endpoints with backend and fix double-prefi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ packages/nestjs-gateway/dist/
 packages/python_backend/__pycache__/
 packages/python_backend/.venv/
 packages/python_backend/*.log
+packages/python_backend/venv/
+venv/

--- a/packages/nestjs-gateway/src/app.controller.ts
+++ b/packages/nestjs-gateway/src/app.controller.ts
@@ -264,4 +264,193 @@ export class AppController {
     );
     return response.data;
   }
+
+  @Post('quality/company/feedback')
+  async saveUserFeedback(@Body() body: any) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/quality/company/feedback`;
+    const response = await firstValueFrom(
+      this.httpService.post(fastApiUrl, body),
+    );
+    return response.data;
+  }
+
+  // ========== Health Endpoints ==========
+
+  @Get('health')
+  async healthCheck() {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/health`;
+    const response = await firstValueFrom(
+      this.httpService.get(fastApiUrl),
+    );
+    return response.data;
+  }
+
+  @Get('db-health')
+  async dbHealth() {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/db-health`;
+    const response = await firstValueFrom(
+      this.httpService.get(fastApiUrl),
+    );
+    return response.data;
+  }
+
+  // ========== Conversion Test Endpoint ==========
+
+  @Get('conversion/test')
+  async conversionTest() {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/conversion/test`;
+    const response = await firstValueFrom(
+      this.httpService.get(fastApiUrl),
+    );
+    return response.data;
+  }
+
+  // ========== Additional RAG Endpoints ==========
+
+  @Post('rag/upload')
+  @UseInterceptors(FileFieldsInterceptor([{ name: 'file', maxCount: 1 }]))
+  async uploadRagFile(@UploadedFiles() files: { file?: any[] }) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/rag/upload`;
+    const FormData = require('form-data');
+    const formData = new FormData();
+
+    if (files?.file?.[0]) {
+      const file = files.file[0];
+      formData.append('file', file.buffer, {
+        filename: file.originalname,
+        contentType: file.mimetype,
+      });
+    }
+
+    const response = await firstValueFrom(
+      this.httpService.post(fastApiUrl, formData, {
+        headers: formData.getHeaders(),
+      }),
+    );
+    return response.data;
+  }
+
+  @Get('rag/status')
+  async getRagStatus() {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/rag/status`;
+    const response = await firstValueFrom(
+      this.httpService.get(fastApiUrl),
+    );
+    return response.data;
+  }
+
+  @Post('rag/analyze-grammar')
+  async analyzeTextGrammar(@Body() body: RAGQueryRequestDto) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/rag/analyze-grammar`;
+    const response = await firstValueFrom(
+      this.httpService.post(fastApiUrl, body),
+    );
+    return response.data;
+  }
+
+  @Post('rag/suggest-expressions')
+  async suggestBetterExpressions(@Body() body: RAGQueryRequestDto) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/rag/suggest-expressions`;
+    const response = await firstValueFrom(
+      this.httpService.post(fastApiUrl, body),
+    );
+    return response.data;
+  }
+
+  @Get('rag/justify-score')
+  async justifyScore(
+    @Query('score_type') scoreType: string,
+    @Query('company_id') companyId?: string,
+  ) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/rag/justify-score`;
+    const response = await firstValueFrom(
+      this.httpService.get(fastApiUrl, {
+        params: { score_type: scoreType, ...(companyId ? { company_id: companyId } : {}) },
+      }),
+    );
+    return response.data;
+  }
+
+  // ========== Documents Text Ingest ==========
+
+  @Post('documents/ingest-text')
+  async ingestTextDocument(@Body() body: any) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/documents/ingest-text`;
+    const response = await firstValueFrom(
+      this.httpService.post(fastApiUrl, body),
+    );
+    return response.data;
+  }
+
+  // ========== Knowledge Base Endpoints ==========
+
+  @Post('kb/upload')
+  @UseInterceptors(FileFieldsInterceptor([{ name: 'file', maxCount: 1 }]))
+  async uploadKbDocument(
+    @UploadedFiles() files: { file?: any[] },
+    @Body() body: { tenant_id: string; category?: string; doc_id?: string },
+  ) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/kb/upload`;
+    const FormData = require('form-data');
+    const formData = new FormData();
+
+    if (files?.file?.[0]) {
+      const file = files.file[0];
+      formData.append('file', file.buffer, {
+        filename: file.originalname,
+        contentType: file.mimetype,
+      });
+    }
+
+    formData.append('tenant_id', body.tenant_id);
+    if (body.category) formData.append('category', body.category);
+    if (body.doc_id) formData.append('doc_id', body.doc_id);
+
+    const response = await firstValueFrom(
+      this.httpService.post(fastApiUrl, formData, {
+        headers: formData.getHeaders(),
+      }),
+    );
+    return response.data;
+  }
+
+  // ========== Suggest Endpoints ==========
+
+  @Post('suggest/rewrite')
+  async suggestRewrite(@Body() body: any) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/suggest/rewrite`;
+    const response = await firstValueFrom(
+      this.httpService.post(fastApiUrl, body),
+    );
+    return response.data;
+  }
+
+  @Post('suggest/finalize')
+  async suggestFinalize(@Body() body: any) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/suggest/finalize`;
+    const response = await firstValueFrom(
+      this.httpService.post(fastApiUrl, body),
+    );
+    return response.data;
+  }
+
+  // ========== Company Profile Endpoints ==========
+
+  @Post('company-profile/generate')
+  async generateCompanyProfile(@Body() body: any) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/company-profile/generate`;
+    const response = await firstValueFrom(
+      this.httpService.post(fastApiUrl, body),
+    );
+    return response.data;
+  }
+
+  @Get('company-profile/:userId')
+  async getCompanyProfile(@Param('userId') userId: string) {
+    const fastApiUrl = `${this.fastApiBaseUrl}/api/v1/company-profile/${userId}`;
+    const response = await firstValueFrom(
+      this.httpService.get(fastApiUrl),
+    );
+    return response.data;
+  }
 }

--- a/packages/python_backend/api/v1/endpoints/kb.py
+++ b/packages/python_backend/api/v1/endpoints/kb.py
@@ -7,7 +7,7 @@ from services.embedding_service import EmbeddingService
 from services.vector_store_pg import VectorStorePG
 
 
-router = APIRouter(prefix="/kb", tags=["kb"])
+router = APIRouter(tags=["kb"])
 
 
 class UploadResponse(BaseModel):

--- a/packages/python_backend/api/v1/endpoints/suggest.py
+++ b/packages/python_backend/api/v1/endpoints/suggest.py
@@ -14,7 +14,7 @@ from services.embedding_service import EmbeddingService
 from services.vector_store_pg import VectorStorePG
 
 
-router = APIRouter(prefix="/suggest", tags=["suggest"])
+router = APIRouter(tags=["suggest"])
 
 
 @router.post("/rewrite", response_model=SuggestRewriteResponse)


### PR DESCRIPTION
…x routes

Add 15 missing proxy endpoints to NestJS gateway (health, RAG upload/status/grammar/expressions/justify-score, kb/upload, suggest/rewrite/finalize, company-profile/generate/get, documents/ingest-text, quality/feedback, conversion/test, db-health) to ensure full backend-gateway alignment.

Fix double-prefix bug in Python backend where kb.py and suggest.py had prefix in both APIRouter and router.py, causing routes like /api/v1/suggest/suggest/rewrite instead of /api/v1/suggest/rewrite.

프백연동 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive set of API endpoints for user feedback, system health monitoring, document management (upload, summarize, delete), knowledge base operations, text analysis features (grammar checking, expression suggestions), rewrite capabilities, and company profile generation.

* **Chores**
  * Updated .gitignore to exclude Python virtual environment directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->